### PR TITLE
Update example.ino

### DIFF
--- a/example.ino
+++ b/example.ino
@@ -13,8 +13,9 @@ void setup() {
   Serial.begin(9600);
   // Addresses we have chosen:
   char addresses[3] = {0x8, 0x9, 0xA};
-  // Addresses are: 0b 0000 1000, 0b 0000 1001 and 0b 0000 1010 so the resultant mask will be: 0b 0000 0011
-  // This means that the address 0b 0000 1011 will also be active.
+  // I2C has a 7 bit address space, as the last bit sets read or write. 
+  // The 7bit addresses are: 0b 0001 000x, 0b 0001 001x and 0b 0001 010x so the resultant mask will be: 0b 0000 011x ( x is the read/write bit)
+  // This means that the address 0b 0001 011x will also be active.
   WireSim.begin(addresses[0], 3);
   // Attach a function to trigger when something is received.
   WireSim.onReceive(receiveEvent);


### PR DESCRIPTION
As i2c uses 7 bits for the address + 1 bit to set read or write. The example uses 8 bits for the addresses. I'm proposing this correction to ensure everyone understands.